### PR TITLE
Feature/debian 9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,15 @@ Dependencies
 
 none
 
+Known issues
+------------
+
+When running on Debian with system-wide install, rbenv won't work from
+`sudo -s` shells. If you need rbenv commands within sudo shells, use `sudo -i`.
+This will launch login shell that will read the rbenv configuration snippet
+from `/etc/profile.d/rbenv.sh` (alternatively, you can manually source that
+file from `sudo -s` shell).
+
 License
 -------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ rbenv_apt_packages:
   - libcurl4-openssl-dev
   - libffi-dev
   - libreadline-dev
-  - libssl-dev
+  - libssl1.0-dev
   - libxml2-dev
   - libxslt1-dev
   - patch

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -52,7 +52,7 @@
   lineinfile:
     dest: /etc/sudoers
     regexp:
-      '^\s*Defaults\s+secure_path\s*=\s*.*:{{ rbenv_root }}/bin(:|$)'
+      '^\s*Defaults\s+secure_path\s*=\s*.*:{{ rbenv_root }}/bin(:|"?$)'
     state: absent
   check_mode: true
   register: rbenv_secure_path_check
@@ -65,8 +65,8 @@
     dest: /etc/sudoers
     backrefs: true
     regexp:
-      '^#?\s*Defaults\s+secure_path\s*=\s*(.*)$'
-    line: 'Defaults    secure_path = \1:{{ rbenv_root }}/bin'
+      '^#?\s*Defaults\s+secure_path\s*=\s*"?([^"]*)("?)$'
+    line: 'Defaults    secure_path = \2\1:{{ rbenv_root }}/bin\2'
     validate: 'visudo -cf %s'
   become: yes
   when: rbenv_set_secure_path and not rbenv_secure_path_check.changed

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -57,7 +57,7 @@
   check_mode: true
   register: rbenv_secure_path_check
   become: yes
-  when: rbenv_set_secure_path
+  when: rbenv_set_secure_path | bool
 
 
 - name: "Add {{ rbenv_root }}/bin to sudoer's secure_path"
@@ -69,7 +69,7 @@
     line: 'Defaults    secure_path = \2\1:{{ rbenv_root }}/bin\2'
     validate: 'visudo -cf %s'
   become: yes
-  when: rbenv_set_secure_path and not rbenv_secure_path_check.changed
+  when: (rbenv_set_secure_path | bool) and not rbenv_secure_path_check.changed
 
 - name: Set group ownership of content under rbenv_root
   shell:


### PR DESCRIPTION
Debian 9 requires the following changes:

- libssl headers package is  `libssl1.0-dev`
- sudoers quotes the value for the secure_path variable.

Also, while CentOS 7 system allows using rbenv wrappers from `sudo -s` shell, debian resets the environment and bash does not source files from `/etc/profile.d`. If you need rbenv working in sudo shells, use `sudo -i` (which will start login shell that will source the rbenv snippet from profile.d/rbenv.sh)